### PR TITLE
Bugfix/count server

### DIFF
--- a/packages/app/src/services/command/index.ts
+++ b/packages/app/src/services/command/index.ts
@@ -31,6 +31,7 @@ export async function execute(
         commandName: command.name,
         message: command.message,
         source: command.source,
+        serverId: command.serverId,
         sentAt: new Date(),
     });
 

--- a/packages/app/src/services/generic-command/index.ts
+++ b/packages/app/src/services/generic-command/index.ts
@@ -26,7 +26,11 @@ async function processGenericCommand(
     genericCommand: GenericCommand
 ): Promise<string> {
     const usageCount = hasCommandUsageCount(genericCommand.output)
-        ? await CommandLogDb.count(genericCommand.name)
+        ? await CommandLogDb.count({
+            source: genericCommand.source,
+            serverId: genericCommand.serverId,
+            commandName: genericCommand.name,
+        })
         : 0;
     const output = getGenericCommandOutput(command.arguments, genericCommand, usageCount);
     return output;

--- a/packages/database/src/models/command-log.ts
+++ b/packages/database/src/models/command-log.ts
@@ -5,6 +5,7 @@ export interface CommandLog {
     message: string;
     author: string;
     sentAt: Date;
+    serverId: string;
     source: Source;
     commandName: string;
 }
@@ -22,6 +23,10 @@ const CommandLogSchema = new Schema({
     },
     sentAt: {
         type: Schema.Types.Date,
+        required: true,
+    },
+    serverId: {
+        type: Schema.Types.String,
         required: true,
     },
     source: {

--- a/packages/database/src/repositories/command-log.ts
+++ b/packages/database/src/repositories/command-log.ts
@@ -1,11 +1,13 @@
 import * as yup from "yup";
 import CommandLogDb, { CommandLog } from "../models/command-log";
+import { Source } from "../types";
 
 const CommandLogSchema = yup.object({
     author: yup.string().required("'author' field is required"),
     commandName: yup.string().required("'commandName' field is required"),
     message: yup.string().required("'message' field is required"),
     source: yup.string().required("'source' field is required"),
+    serverId: yup.string().required("'serverId' field is required"),
 });
 
 export async function save(commandLog: CommandLog): Promise<boolean> {
@@ -17,7 +19,17 @@ export async function save(commandLog: CommandLog): Promise<boolean> {
     return true;
 }
 
-export async function count(commandName: string): Promise<number> {
-    const commandLogs = await CommandLogDb.find({ commandName }).lean();
+interface CountParameters {
+    serverId: string;
+    source: Source;
+    commandName: string;
+}
+
+export async function count({ source, serverId, commandName }: CountParameters): Promise<number> {
+    const commandLogs = await CommandLogDb.find({
+        commandName,
+        source: source,
+        serverId,
+     }).lean();
     return commandLogs.length;
 }


### PR DESCRIPTION
Introduced options object as function parameters. This should be always used when there are three or more parameters. Functions with a lot of parameters and no specific type can easily be called with wrong parameter order.